### PR TITLE
Move project to Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,15 @@ In-house MicroService Infrastructure for Disorderly Labs
 2. Gradle
 3. Docker
 
-## Build the images
-Go to individual folders and execute `./gradlew build docker`. You can configure the name of your docker image in the `build.gradle` of each microservice.
-
-## Create Network
-`docker network create --subnet=10.0.0.0/16 mynet`
-
 ## Start the services
+
 ```
-docker run -p 7001:8080 --net=mynet --ip=10.0.0.21 -d com.disorderlylabs/inventory
-docker run -p 7002:8080 --net=mynet --ip=10.0.0.22 -d com.disorderlylabs/cart
-docker run -p 7000:8080 --net=mynet -e inventory_ip=10.0.0.21:8080 -e cart_ip=10.0.0.22:8080 -d com.disorderlylabs/app
+docker-compose up
 ```
+
+Optionally run the containers in the backgorund with the `-d` flag, and run `docker-compose down` to shut off the containers.
 
 ## Run a sample command
 `curl -X PUT "http://localhost:7000/app/addToCart?quantity=3&name=Chamber"`
 
 The above call involves all three microservices. First _'App'_ makes a call to _'Inventory'_, to take the item out of inventory (Inventory Database). Then _'App'_ makes a call to _'Cart'_, to add the item to the Cart (Cart Database).         
-

--- a/app/dockerfile
+++ b/app/dockerfile
@@ -1,3 +1,4 @@
+RUN ./gradlew build docker
 FROM openjdk:8-jdk-alpine
 VOLUME /tmp
 ARG JAR_FILE

--- a/app/src/main/java/com/disorderlylabs/app/controllers/Controller.java
+++ b/app/src/main/java/com/disorderlylabs/app/controllers/Controller.java
@@ -36,16 +36,11 @@ public class Controller {
 
   @Autowired
   JdbcTemplate jdbcTemplate;
-  private static final String inventory_URL = "http://localhost:7002";
+  private static final String inventory_URL = "http://inventory";
 
   @RequestMapping("/")
   public String index() {
       return "Greetings from App Microservice!";
-  }
-
-  @RequestMapping("/checkEnv")
-  public String checkEnv() {
-      return System.getenv("inventory_ip") + "";
   }
 
   //******--------For this particular request 'App' is acting like a forwarding node to 'Inventory'--------******.
@@ -54,7 +49,7 @@ public class Controller {
   {
     try
     {
-      String url = "http://" + System.getenv("inventory_ip") + "/takeFromInventory";
+      String url = inventory_URL + "/takeFromInventory";
       HttpClient client = new DefaultHttpClient();
       HttpPut put = new HttpPut(url);
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  app:
+    container_name: app
+    image: com.disorderlylabs/app
+    ports:
+      - "7001:8080"
+    build:
+      context: ./app
+
+  inventory:
+    container_name: inventory
+    image: com.disorderlylabs/inventory
+    ports:
+      - "7000:8080"
+    build:
+      context: ./inventory

--- a/inventory/dockerfile
+++ b/inventory/dockerfile
@@ -1,3 +1,4 @@
+RUN ./gradlew build docker
 FROM openjdk:8-jdk-alpine
 VOLUME /tmp
 ARG JAR_FILE


### PR DESCRIPTION
This reconfigures the project to use Docker Compose, primarily to simplify configuration and make service discovery less manual. Compose makes this [particularly simple](https://docs.docker.com/compose/networking/) as it lets us specify apps in `docker-compose.yaml` that can talk to each other via a network created by default. See the link for more details about how this works.

We can talk to our containers over the ports specified in `docker-compose.yaml`, which follow the format "host-port:container-port". Docker handles all the networking around forwarding traffic from the host port to the container port.

This cannot be merged as-is, because I think there is an issue around Spring not liking custom hostnames. I suspect there may be an additional method that needs to be called to set a custom hostname on the request in `app/.../Controller.java`, but did not play with this much myself as I don't have a Java development environment set up, and for some reason requests do not seem to be showing up in the Spring logs that we see when running `docker-compose up` or `docker-compose logs app`. 

The specific error I get when doing a `PUT` to `http://0.0.0.0:7001/takeFromInventory?name=Chamber&quantity=1` is `java.net.ConnectException: Connection refused (Connection refused)`. The issue does not seem to be with the Docker networking configuration because we're making it to the Java app, and because I can make requests to the `inventory` app by itself without any issues.